### PR TITLE
fix: change telegramUserId from header to RequestParam

### DIFF
--- a/src/main/java/me/forty2/watloo/controller/CourseTableController.java
+++ b/src/main/java/me/forty2/watloo/controller/CourseTableController.java
@@ -23,12 +23,12 @@ public class CourseTableController {
 
     @GetMapping("/courses")
     public ResponseEntity<?> getCourses(
-            @RequestHeader(value = "X-Telegram-User-Id", required = false) Long telegramUserId,
+            @RequestParam(value = "userId", required = false) Long telegramUserId,
             @RequestParam(value = "view", defaultValue = "week") String view,
             @RequestParam(value = "date", required = false) String date) {
 
         if (telegramUserId == null) {
-            return error(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "missing X-Telegram-User-Id header");
+            return error(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "missing userId parameter");
         }
 
         BotUser botUser = userService.getByTelegramId(telegramUserId);


### PR DESCRIPTION
I have updated the CourseTableController to use @RequestParam instead of @RequestHeader for the userId, as requested in Issue #71.

Changes:

Changed @RequestHeader to @RequestParam(value = "userId", required = false).

Updated the error message to be consistent with the new parameter.

Verified locally: the backend correctly identifies the parameter in the query string and responds accordingly.

(Note: I am still waiting for my Waterloo API Key to test real data fetching, but the structural change is completed).